### PR TITLE
Update curator version to 5.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:alpine
 
-RUN pip install -U --quiet elasticsearch-curator==5.4.1
+RUN pip install -U --quiet elasticsearch-curator==5.5.1
 
 ENTRYPOINT [ "/usr/local/bin/curator" ]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Lean Elasticsearch Curator container image, based on Alpine Linux 3.7 and Python
 ## Current software
 
 * Python 3
-* Curator 5.4.1
+* Curator 5.5.1
 
 ## Usage
 
 ```
-docker pull quay.io/pires/docker-elasticsearch-curator:5.4.1
+docker pull quay.io/pires/docker-elasticsearch-curator:5.5.1
 ```


### PR DESCRIPTION
Curator version 5.5.x got released a few weeks ago and comes with some new features and bugfixes:
https://github.com/elastic/curator/releases