### PR TITLE
Upgrade to curator 5.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:alpine
 
-RUN pip install -U --quiet elasticsearch-curator==5.5.1
+RUN pip install -U --quiet elasticsearch-curator==5.5.4
 
 ENTRYPOINT [ "/usr/local/bin/curator" ]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Lean Elasticsearch Curator container image, based on Alpine Linux 3.7 and Python
 ## Current software
 
 * Python 3
-* Curator 5.5.1
+* Curator 5.5.4
 
 ## Usage
 
 ```
-docker pull quay.io/pires/docker-elasticsearch-curator:5.5.1
+docker pull quay.io/pires/docker-elasticsearch-curator:5.5.4
 ```


### PR DESCRIPTION
Useful bugfixes were added in the later releases: https://github.com/elastic/curator/releases